### PR TITLE
Feat: 立て替え追加・削除のユースケースを追加

### DIFF
--- a/Roulette/Model/Member.swift
+++ b/Roulette/Model/Member.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct Member: Identifiable, Codable {
     var id = UUID()
-    var name: String
+    private(set) var name: String
 }

--- a/Roulette/Model/Member.swift
+++ b/Roulette/Model/Member.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct Member: Identifiable, Codable {
     var id = UUID()
-    let name: String
+    var name: String
 }

--- a/Roulette/Model/Seisan.swift
+++ b/Roulette/Model/Seisan.swift
@@ -11,9 +11,9 @@ import Foundation
 /// 清算の一手順。
 struct Seisan {
     /// 債務者。清算で支払いをする人。
-    let debtor: Member
+    private(set) var debtor: Member
     /// 債権者。清算で受け取る側の人。
-    let creditor: Member
+    private(set) var creditor: Member
     /// 清算額。
-    let money: Int
+    private(set) var money: Int
 }

--- a/Roulette/Model/Tatekae.swift
+++ b/Roulette/Model/Tatekae.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Tatekae: Identifiable, Codable {
     var id = UUID()
-    let payer: Member
-    let recipients: [Member]
-    let money: Int
+    var payer: Member
+    var recipients: [Member]
+    var money: Int
 }

--- a/Roulette/Model/Tatekae.swift
+++ b/Roulette/Model/Tatekae.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct Tatekae: Identifiable, Codable {
     var id = UUID()
+    var name: String
     var payer: Member
     var recipients: [Member]
     var money: Int

--- a/Roulette/Model/WarikanGroup.swift
+++ b/Roulette/Model/WarikanGroup.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct WarikanGroup: Identifiable, Codable {
     var id = UUID()
-    var name: String
+    private(set) var name: String
     var members: [Member]
     var tatekaeList: [Tatekae]
 }

--- a/Roulette/Model/WarikanGroup.swift
+++ b/Roulette/Model/WarikanGroup.swift
@@ -9,6 +9,6 @@ import Foundation
 
 struct WarikanGroup: Identifiable, Codable {
     var id = UUID()
-    let name: String
-    let members: [Member]
+    var name: String
+    var members: [Member]
 }

--- a/Roulette/Model/WarikanGroup.swift
+++ b/Roulette/Model/WarikanGroup.swift
@@ -11,4 +11,5 @@ struct WarikanGroup: Identifiable, Codable {
     var id = UUID()
     var name: String
     var members: [Member]
+    var tatekaeList: [Tatekae]
 }

--- a/Roulette/Model/WarikanGroupUseCase.swift
+++ b/Roulette/Model/WarikanGroupUseCase.swift
@@ -46,22 +46,18 @@ struct WarikanGroupUsecase {
     func createMember(warikanGroupID: UUID, name: String) async throws {
         let newMember = Member(name: name)
         try await warikanGroupRepository.transaction {
-            let warikanGroup = try await warikanGroupRepository.find(id: warikanGroupID)!
-            try await warikanGroupRepository.save(
-                // TODO: IDを使って生成しているので要修正
-                WarikanGroup(id: warikanGroupID, name: warikanGroup.name, members: warikanGroup.members + [newMember])
-            )
+            var warikanGroup = try await warikanGroupRepository.find(id: warikanGroupID)!
+            warikanGroup.members.append(newMember)
+            try await warikanGroupRepository.save(warikanGroup)
         }
     }
     
     /// メンバーを削除する。
     func removeMember(warikanGroupID: UUID, memberID: UUID) async throws {
         try await warikanGroupRepository.transaction {
-            let warikanGroup = try await warikanGroupRepository.find(id: warikanGroupID)!
-            try await warikanGroupRepository.save(
-                // TODO: IDを使って生成しているので要修正
-                WarikanGroup(id: warikanGroupID, name: warikanGroup.name, members: warikanGroup.members.filter { $0.id != memberID })
-            )
+            var warikanGroup = try await warikanGroupRepository.find(id: warikanGroupID)!
+            warikanGroup.members.removeAll { $0.id != memberID }
+            try await warikanGroupRepository.save(warikanGroup)
         }
     }
 }

--- a/Roulette/Model/WarikanGroupUseCase.swift
+++ b/Roulette/Model/WarikanGroupUseCase.swift
@@ -26,7 +26,7 @@ struct WarikanGroupUsecase {
     func create(name: String, memberNames: [String]) async throws {
         let members = memberNames.map { Member(name: $0) }
         try await warikanGroupRepository.transaction {
-            try await warikanGroupRepository.save(WarikanGroup(name: name, members: members))
+            try await warikanGroupRepository.save(WarikanGroup(name: name, members: members, tatekaeList: []))
         }
     }
     

--- a/Roulette/Model/WarikanGroupUseCase.swift
+++ b/Roulette/Model/WarikanGroupUseCase.swift
@@ -56,7 +56,7 @@ struct WarikanGroupUsecase {
     func removeMember(warikanGroupID: UUID, memberID: UUID) async throws {
         try await warikanGroupRepository.transaction {
             var warikanGroup = try await warikanGroupRepository.find(id: warikanGroupID)!
-            warikanGroup.members.removeAll { $0.id != memberID }
+            warikanGroup.members.removeAll { $0.id == memberID }
             try await warikanGroupRepository.save(warikanGroup)
         }
     }

--- a/Roulette/Model/WarikanGroupUseCase.swift
+++ b/Roulette/Model/WarikanGroupUseCase.swift
@@ -60,4 +60,23 @@ struct WarikanGroupUsecase {
             try await warikanGroupRepository.save(warikanGroup)
         }
     }
+    
+    /// 立て替えを追加する。
+    func appendTatekae(warikanGroupID: UUID, tatekaeName: String, payer: Member, recipants: [Member], money: Int) async throws {
+        let newTatekae = Tatekae(name: tatekaeName, payer: payer, recipients: recipants, money: money)
+        try await warikanGroupRepository.transaction {
+            var warikanGroup = try await warikanGroupRepository.find(id: warikanGroupID)!
+            warikanGroup.tatekaeList.append(newTatekae)
+            try await warikanGroupRepository.save(warikanGroup)
+        }
+    }
+    
+    /// 立て替えを一件削除する。
+    func removeTatekae(warikanGroupID: UUID, tatekaeID: UUID) async throws {
+        try await warikanGroupRepository.transaction {
+            var warikanGroup = try await warikanGroupRepository.find(id: warikanGroupID)!
+            warikanGroup.tatekaeList.removeAll { $0.id == tatekaeID }
+            try await warikanGroupRepository.save(warikanGroup)
+        }
+    }
 }


### PR DESCRIPTION
## 追加したユースケース
立て替え追加
`func appendTatekae(warikanGroupID: UUID, tatekaeName: String, payer: Member, recipants: [Member], money: Int) async throws`
立て替え削除
`func removeTatekae(warikanGroupID: UUID, tatekaeID: UUID) async throws`

# 課題
- ユースケースで`Member`を引数にするのはよくなさそう。(SeisanCalculatorもそう)
- そもそも`Tatekae`が`Member`を保持していることがおかしい。`WarikanGroup`が保持している`members`との整合性を保証する必要がある。

次のプルリクで改善する予定。