### PR TITLE
Refactor: warikanGroupUseCase.remove(ids:)内の変数名を修正

### DIFF
--- a/Roulette/Model/UseCase/WarikanGroupUseCase.swift
+++ b/Roulette/Model/UseCase/WarikanGroupUseCase.swift
@@ -44,16 +44,15 @@ struct WarikanGroupUsecase {
     /// 指定したIDの割り勘グループを削除する。
     func remove(ids: [EntityID<WarikanGroup>]) async throws {
         try await warikanGroupRepository.transaction {
-            var warikanGroups = [WarikanGroup]()
+            var targets = [WarikanGroup]()
             for id in ids {
                 guard let warikanGroup = try await warikanGroupRepository.find(id: id) else {
                     throw ValidationError.notFoundID(id)
                 }
-                // FIXME: appendになってる？？
-                warikanGroups.append(warikanGroup)
+                targets.append(warikanGroup)
             }
             
-            for warikanGroup in warikanGroups {
+            for warikanGroup in targets {
                 try await warikanGroupRepository.remove(id: warikanGroup.id)
                 try await memberRepository.transaction {
                     try await memberRepository.remove(ids: warikanGroup.members)


### PR DESCRIPTION
close #25 

`remove(ids:)`というメソッド内で、変数`warikanGroups`へのappendが行われており、不自然に思えた。
紛らわしいので、変数`warikanGroups`を`targets`に変更した。