### PR TITLE
Feat: 割り勘グループのアーカイブに関するユースケースを追加

### DIFF
--- a/Roulette.xcodeproj/project.pbxproj
+++ b/Roulette.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		A600912F2B2298B6005C6535 /* ArchivedWarikanGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */; };
 		A60091312B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60091302B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift */; };
 		A60091332B22A05D005C6535 /* WarikanGroupArchiveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60091322B22A05D005C6535 /* WarikanGroupArchiveController.swift */; };
+		A60091352B22B857005C6535 /* ArchivedWarikanGroupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60091342B22B857005C6535 /* ArchivedWarikanGroupUseCase.swift */; };
 		A67FE31A2B1337FA00E10FFB /* SeisanCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */; };
 		A67FE31D2B1338A900E10FFB /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE31C2B1338A900E10FFB /* Extensions.swift */; };
 		A67FE3242B14657400E10FFB /* WarikanGroupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */; };
@@ -97,6 +98,7 @@
 		A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroup.swift; sourceTree = "<group>"; };
 		A60091302B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroupRepositoryProtocol.swift; sourceTree = "<group>"; };
 		A60091322B22A05D005C6535 /* WarikanGroupArchiveController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarikanGroupArchiveController.swift; sourceTree = "<group>"; };
+		A60091342B22B857005C6535 /* ArchivedWarikanGroupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroupUseCase.swift; sourceTree = "<group>"; };
 		A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeisanCalculator.swift; sourceTree = "<group>"; };
 		A67FE31C2B1338A900E10FFB /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarikanGroupUseCase.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				A67FE3522B1C923A00E10FFB /* TatekaeUseCase.swift */,
 				4C6528302B2208C4000E8130 /* SeisanCalculator */,
 				A60091322B22A05D005C6535 /* WarikanGroupArchiveController.swift */,
+				A60091342B22B857005C6535 /* ArchivedWarikanGroupUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -424,6 +427,7 @@
 				4C65282B2B220231000E8130 /* LongStyle.swift in Sources */,
 				4C65283E2B220D6F000E8130 /* TatekaeListViewModel.swift in Sources */,
 				A67FE3402B1C345D00E10FFB /* EntityID.swift in Sources */,
+				A60091352B22B857005C6535 /* ArchivedWarikanGroupUseCase.swift in Sources */,
 				A67FE3532B1C923A00E10FFB /* TatekaeUseCase.swift in Sources */,
 				4C6528402B220D80000E8130 /* AddTatekaeViewModel.swift in Sources */,
 				4C1C38E62B1E0B7E00839663 /* AddTatekaeView.swift in Sources */,

--- a/Roulette.xcodeproj/project.pbxproj
+++ b/Roulette.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		69D8F3EA2B1F478500B24D4E /* RouletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D8F3E92B1F478500B24D4E /* RouletteView.swift */; };
 		69D8F3EC2B1F4AC100B24D4E /* RouletteResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D8F3EB2B1F4AC100B24D4E /* RouletteResultView.swift */; };
 		69D8F3EE2B1F4ACE00B24D4E /* SeisanResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D8F3ED2B1F4ACE00B24D4E /* SeisanResultView.swift */; };
+		A600912F2B2298B6005C6535 /* ArchivedWarikanGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */; };
 		A67FE31A2B1337FA00E10FFB /* SeisanCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */; };
 		A67FE31D2B1338A900E10FFB /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE31C2B1338A900E10FFB /* Extensions.swift */; };
 		A67FE3242B14657400E10FFB /* WarikanGroupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */; };
@@ -91,6 +92,7 @@
 		69D8F3E92B1F478500B24D4E /* RouletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouletteView.swift; sourceTree = "<group>"; };
 		69D8F3EB2B1F4AC100B24D4E /* RouletteResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouletteResultView.swift; sourceTree = "<group>"; };
 		69D8F3ED2B1F4ACE00B24D4E /* SeisanResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeisanResultView.swift; sourceTree = "<group>"; };
+		A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroup.swift; sourceTree = "<group>"; };
 		A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeisanCalculator.swift; sourceTree = "<group>"; };
 		A67FE31C2B1338A900E10FFB /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarikanGroupUseCase.swift; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 			children = (
 				A67FE33F2B1C345D00E10FFB /* EntityID.swift */,
 				4C6528312B2208DB000E8130 /* WarikanGroup */,
+				A600912D2B229888005C6535 /* ArchivedWarikanGroup */,
 				4C6528322B2208EC000E8130 /* Member */,
 				4C6528332B2208F5000E8130 /* Tatekae */,
 			);
@@ -241,7 +244,6 @@
 			isa = PBXGroup;
 			children = (
 				A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */,
-				A67FE33D2B19679400E10FFB /* Seisan.swift */,
 				A67FE35A2B1CA2F300E10FFB /* DebtState.swift */,
 			);
 			path = SeisanCalculator;
@@ -296,6 +298,15 @@
 				4C65284B2B220DEB000E8130 /* ArchiveViewModel.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		A600912D2B229888005C6535 /* ArchivedWarikanGroup */ = {
+			isa = PBXGroup;
+			children = (
+				A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */,
+				A67FE33D2B19679400E10FFB /* Seisan.swift */,
+			);
+			path = ArchivedWarikanGroup;
 			sourceTree = "<group>";
 		};
 		A67FE31B2B13387C00E10FFB /* Util */ = {
@@ -417,6 +428,7 @@
 				4C6528442B220DA3000E8130 /* ConfirmViewModel.swift in Sources */,
 				A67FE3552B1C98D700E10FFB /* InMemoryMemberRepository.swift in Sources */,
 				4CA486312B206001009231FA /* AddButton.swift in Sources */,
+				A600912F2B2298B6005C6535 /* ArchivedWarikanGroup.swift in Sources */,
 				69D8F3EC2B1F4AC100B24D4E /* RouletteResultView.swift in Sources */,
 				4C65284C2B220DEB000E8130 /* ArchiveViewModel.swift in Sources */,
 				A67FE31D2B1338A900E10FFB /* Extensions.swift in Sources */,

--- a/Roulette.xcodeproj/project.pbxproj
+++ b/Roulette.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		69D8F3EE2B1F4ACE00B24D4E /* SeisanResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D8F3ED2B1F4ACE00B24D4E /* SeisanResultView.swift */; };
 		A600912F2B2298B6005C6535 /* ArchivedWarikanGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */; };
 		A60091312B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60091302B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift */; };
+		A60091332B22A05D005C6535 /* WarikanGroupArchiveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60091322B22A05D005C6535 /* WarikanGroupArchiveController.swift */; };
 		A67FE31A2B1337FA00E10FFB /* SeisanCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */; };
 		A67FE31D2B1338A900E10FFB /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE31C2B1338A900E10FFB /* Extensions.swift */; };
 		A67FE3242B14657400E10FFB /* WarikanGroupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */; };
@@ -95,6 +96,7 @@
 		69D8F3ED2B1F4ACE00B24D4E /* SeisanResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeisanResultView.swift; sourceTree = "<group>"; };
 		A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroup.swift; sourceTree = "<group>"; };
 		A60091302B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroupRepositoryProtocol.swift; sourceTree = "<group>"; };
+		A60091322B22A05D005C6535 /* WarikanGroupArchiveController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarikanGroupArchiveController.swift; sourceTree = "<group>"; };
 		A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeisanCalculator.swift; sourceTree = "<group>"; };
 		A67FE31C2B1338A900E10FFB /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarikanGroupUseCase.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 				A67FE3472B1C656500E10FFB /* MemberUseCase.swift */,
 				A67FE3522B1C923A00E10FFB /* TatekaeUseCase.swift */,
 				4C6528302B2208C4000E8130 /* SeisanCalculator */,
+				A60091322B22A05D005C6535 /* WarikanGroupArchiveController.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -414,6 +417,7 @@
 				69D8F3EA2B1F478500B24D4E /* RouletteView.swift in Sources */,
 				4C228AD12AFA861B00FE4F35 /* RouletteApp.swift in Sources */,
 				4C3EB2CC2B1DE63600423444 /* ViewRouter.swift in Sources */,
+				A60091332B22A05D005C6535 /* WarikanGroupArchiveController.swift in Sources */,
 				4C6528422B220D95000E8130 /* TatekaeDetailViewModel.swift in Sources */,
 				A67FE35F2B21D1A600E10FFB /* MemberRepository.swift in Sources */,
 				A67FE35B2B1CA2F300E10FFB /* DebtState.swift in Sources */,

--- a/Roulette.xcodeproj/project.pbxproj
+++ b/Roulette.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		69D8F3EC2B1F4AC100B24D4E /* RouletteResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D8F3EB2B1F4AC100B24D4E /* RouletteResultView.swift */; };
 		69D8F3EE2B1F4ACE00B24D4E /* SeisanResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D8F3ED2B1F4ACE00B24D4E /* SeisanResultView.swift */; };
 		A600912F2B2298B6005C6535 /* ArchivedWarikanGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */; };
+		A60091312B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60091302B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift */; };
 		A67FE31A2B1337FA00E10FFB /* SeisanCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */; };
 		A67FE31D2B1338A900E10FFB /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE31C2B1338A900E10FFB /* Extensions.swift */; };
 		A67FE3242B14657400E10FFB /* WarikanGroupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */; };
@@ -93,6 +94,7 @@
 		69D8F3EB2B1F4AC100B24D4E /* RouletteResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouletteResultView.swift; sourceTree = "<group>"; };
 		69D8F3ED2B1F4ACE00B24D4E /* SeisanResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeisanResultView.swift; sourceTree = "<group>"; };
 		A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroup.swift; sourceTree = "<group>"; };
+		A60091302B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroupRepositoryProtocol.swift; sourceTree = "<group>"; };
 		A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeisanCalculator.swift; sourceTree = "<group>"; };
 		A67FE31C2B1338A900E10FFB /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarikanGroupUseCase.swift; sourceTree = "<group>"; };
@@ -305,6 +307,7 @@
 			children = (
 				A600912E2B2298B6005C6535 /* ArchivedWarikanGroup.swift */,
 				A67FE33D2B19679400E10FFB /* Seisan.swift */,
+				A60091302B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift */,
 			);
 			path = ArchivedWarikanGroup;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 			files = (
 				A67FE32F2B154B5C00E10FFB /* InMemoryWarikanGroupRepository.swift in Sources */,
 				69D8F3E62B1E011A00B24D4E /* ConfirmView.swift in Sources */,
+				A60091312B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift in Sources */,
 				4C25180E2B12108D00965D43 /* Tatekae.swift in Sources */,
 				A67FE3592B1C9A8B00E10FFB /* ValidationError.swift in Sources */,
 				4C228AD32AFA861B00FE4F35 /* ContentView.swift in Sources */,

--- a/Roulette/Model/Repository/ArchivedWarikanGroup/ArchivedWarikanGroup.swift
+++ b/Roulette/Model/Repository/ArchivedWarikanGroup/ArchivedWarikanGroup.swift
@@ -1,0 +1,18 @@
+//
+//  ArchivedWarikanGroup.swift
+//  Roulette
+//  
+//  Created by Seigetsu on 2023/12/08
+//  
+//
+
+import Foundation
+
+struct ArchivedWarikanGroup: Identifiable, Codable {
+    var id: EntityID<Self>
+    private(set) var name: String
+    private(set) var members: [EntityID<Member>]
+    private(set) var tatekaeList: [EntityID<Tatekae>]
+    private(set) var unluckyMember: EntityID<Member>?
+    private(set) var seisanList: [Seisan]
+}

--- a/Roulette/Model/Repository/ArchivedWarikanGroup/ArchivedWarikanGroupRepositoryProtocol.swift
+++ b/Roulette/Model/Repository/ArchivedWarikanGroup/ArchivedWarikanGroupRepositoryProtocol.swift
@@ -11,7 +11,7 @@ import Foundation
 /// `ArchivedWarikanGroup`のCRUD操作のために、データベースとやり取りを行うメソッド。
 protocol ArchivedWarikanGroupRepositoryProtocol {
     /// データベースのトランザクションを実行する。
-    func transaction(block: () async throws -> ()) async throws
+    func transaction<Result>(block: () async throws -> Result) async throws -> Result
     
     /// 採番処理を行い、新しいIDを生成する。
     func nextID() async throws -> EntityID<ArchivedWarikanGroup>

--- a/Roulette/Model/Repository/ArchivedWarikanGroup/ArchivedWarikanGroupRepositoryProtocol.swift
+++ b/Roulette/Model/Repository/ArchivedWarikanGroup/ArchivedWarikanGroupRepositoryProtocol.swift
@@ -1,0 +1,32 @@
+//
+//  ArchivedWarikanGroupRepositoryProtocol.swift
+//  Roulette
+//  
+//  Created by Seigetsu on 2023/12/08
+//  
+//
+
+import Foundation
+
+/// `ArchivedWarikanGroup`のCRUD操作のために、データベースとやり取りを行うメソッド。
+protocol ArchivedWarikanGroupRepositoryProtocol {
+    /// データベースのトランザクションを実行する。
+    func transaction(block: () async throws -> ()) async throws
+    
+    /// 採番処理を行い、新しいIDを生成する。
+    func nextID() async throws -> EntityID<ArchivedWarikanGroup>
+    
+    /// 清算済グループを全件取得する。
+    func findAll() async throws -> [ArchivedWarikanGroup]
+    
+    /// 指定したIDの清算済グループを全件取得する。
+    func find(id: EntityID<ArchivedWarikanGroup>) async throws -> ArchivedWarikanGroup?
+    
+    /// 清算済グループを保存する。
+    ///
+    /// 既に存在するIDの場合は更新、存在しないIDの場合は末尾に新規作成する。
+    func save(_ item: ArchivedWarikanGroup) async throws
+    
+    /// 指定したインデックスの清算済グループを削除する。
+    func remove(id: EntityID<ArchivedWarikanGroup>) async throws
+}

--- a/Roulette/Model/Repository/ArchivedWarikanGroup/Seisan.swift
+++ b/Roulette/Model/Repository/ArchivedWarikanGroup/Seisan.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// 清算の一手順。
-struct Seisan {
+struct Seisan: Codable {
     /// 債務者。清算で支払いをする人。
     private(set) var debtor: EntityID<Member>
     /// 債権者。清算で受け取る側の人。

--- a/Roulette/Model/Repository/WarikanGroup/InMemoryWarikanGroupRepository.swift
+++ b/Roulette/Model/Repository/WarikanGroup/InMemoryWarikanGroupRepository.swift
@@ -12,7 +12,7 @@ import Foundation
 class InMemoryWarikanGroupRepository: WarikanGroupRepositoryProtocol {
     private var items = [WarikanGroup]()
     
-    func transaction(block: () async throws -> ()) async throws {
+    func transaction<Result>(block: () async throws -> Result) async throws -> Result {
         try await block()
     }
     

--- a/Roulette/Model/Repository/WarikanGroup/WarikanGroupRepository.swift
+++ b/Roulette/Model/Repository/WarikanGroup/WarikanGroupRepository.swift
@@ -21,7 +21,7 @@ struct WarikanGroupRepository: WarikanGroupRepositoryProtocol {
     }
     
     /// - NOTE: UserDefaultsにトランザクションの仕組みは存在しないため、実装していない。
-    func transaction(block: () async throws -> ()) async throws {
+    func transaction<Result>(block: () async throws -> Result) async throws -> Result {
         try await block()
     }
     

--- a/Roulette/Model/Repository/WarikanGroup/WarikanGroupRepositoryProtocol.swift
+++ b/Roulette/Model/Repository/WarikanGroup/WarikanGroupRepositoryProtocol.swift
@@ -11,7 +11,7 @@ import Foundation
 /// `WarikanGroup`配列のCRUD操作のために、データベースとやり取りを行うメソッド。
 protocol WarikanGroupRepositoryProtocol {
     /// データベースのトランザクションを実行する。
-    func transaction(block: () async throws -> ()) async throws
+    func transaction<Result>(block: () async throws -> Result) async throws -> Result
     
     /// 採番処理を行い、新しいIDを生成する。
     func nextID() async throws -> EntityID<WarikanGroup>

--- a/Roulette/Model/UseCase/ArchivedWarikanGroupUseCase.swift
+++ b/Roulette/Model/UseCase/ArchivedWarikanGroupUseCase.swift
@@ -1,0 +1,44 @@
+//
+//  ArchivedWarikanGroupUseCase.swift
+//  Roulette
+//  
+//  Created by Seigetsu on 2023/12/08
+//  
+//
+
+import Foundation
+
+struct ArchivedWarikanGroupUseCase {
+    private var repository: ArchivedWarikanGroupRepositoryProtocol
+    private var memberRepository: MemberRepositoryProtocol
+    
+    init(archivedWarikanGroupRepository: ArchivedWarikanGroupRepositoryProtocol, memberRepository: MemberRepositoryProtocol) {
+        self.repository = archivedWarikanGroupRepository
+        self.memberRepository = memberRepository
+    }
+    
+    /// 登録されている割り勘グループの配列の全体を返す。
+    func getAll() async throws -> [ArchivedWarikanGroup] {
+        return try await repository.findAll()
+    }
+    
+    /// 指定したIDの割り勘グループを削除する。
+    func remove(ids: [EntityID<ArchivedWarikanGroup>]) async throws {
+        try await repository.transaction {
+            var targets = [ArchivedWarikanGroup]()
+            for id in ids {
+                guard let warikanGroup = try await repository.find(id: id) else {
+                    throw ValidationError.notFoundID(id)
+                }
+                targets.append(warikanGroup)
+            }
+            
+            for warikanGroup in targets {
+                try await repository.remove(id: warikanGroup.id)
+                try await memberRepository.transaction {
+                    try await memberRepository.remove(ids: warikanGroup.members)
+                }
+            }
+        }
+    }
+}

--- a/Roulette/Model/UseCase/WarikanGroupArchiveController.swift
+++ b/Roulette/Model/UseCase/WarikanGroupArchiveController.swift
@@ -23,6 +23,7 @@ struct WarikanGroupArchiveController {
     /// - parameter id: アーカイブする割り勘グループ。
     /// - parameter seisanList: その割り勘グループで計算された清算リスト。
     /// - parameter unluckyMember: 選ばれたアンラッキーメンバー。アンラッキーメンバーがいない場合は`nil`を渡す。
+    /// - returns: アーカイブ後の清算済グループの識別子。
     func archive(id: EntityID<WarikanGroup>, seisanList: [Seisan], unluckyMember: EntityID<Member>?) async throws -> EntityID<ArchivedWarikanGroup> {
         return try await warikanGroupRepository.transaction {
             // 割り勘グループのリポジトリから削除

--- a/Roulette/Model/UseCase/WarikanGroupArchiveController.swift
+++ b/Roulette/Model/UseCase/WarikanGroupArchiveController.swift
@@ -23,8 +23,8 @@ struct WarikanGroupArchiveController {
     /// - parameter id: アーカイブする割り勘グループ。
     /// - parameter seisanList: その割り勘グループで計算された清算リスト。
     /// - parameter unluckyMember: 選ばれたアンラッキーメンバー。アンラッキーメンバーがいない場合は`nil`を渡す。
-    func archive(id: EntityID<WarikanGroup>, seisanList: [Seisan], unluckyMember: EntityID<Member>?) async throws {
-        try await warikanGroupRepository.transaction {
+    func archive(id: EntityID<WarikanGroup>, seisanList: [Seisan], unluckyMember: EntityID<Member>?) async throws -> EntityID<ArchivedWarikanGroup> {
+        return try await warikanGroupRepository.transaction {
             // 割り勘グループのリポジトリから削除
             guard let target = try await warikanGroupRepository.find(id: id) else {
                 throw ValidationError.notFoundID(id)
@@ -32,7 +32,7 @@ struct WarikanGroupArchiveController {
             try await warikanGroupRepository.remove(id: target.id)
             
             // 清算済グループのリポジトリに保存
-            try await archivedWarikanGroupRepository.transaction {
+            return try await archivedWarikanGroupRepository.transaction {
                 let archivedWarikanGroupID = try await archivedWarikanGroupRepository.nextID()
                 let archivedWarikanGroup = ArchivedWarikanGroup(
                     id: archivedWarikanGroupID,
@@ -43,6 +43,7 @@ struct WarikanGroupArchiveController {
                     seisanList: seisanList
                 )
                 try await archivedWarikanGroupRepository.save(archivedWarikanGroup)
+                return archivedWarikanGroupID
             }
         }
     }

--- a/Roulette/Model/UseCase/WarikanGroupArchiveController.swift
+++ b/Roulette/Model/UseCase/WarikanGroupArchiveController.swift
@@ -1,0 +1,49 @@
+//
+//  WarikanGroupArchiveController.swift
+//  Roulette
+//  
+//  Created by Seigetsu on 2023/12/08
+//  
+//
+
+import Foundation
+
+/// 割り勘グループのアーカイブ制御についてのユースケースを提供する。
+struct WarikanGroupArchiveController {
+    private var warikanGroupRepository: WarikanGroupRepositoryProtocol
+    private var archivedWarikanGroupRepository: ArchivedWarikanGroupRepositoryProtocol
+    
+    init(warikanGroupRepository: WarikanGroupRepositoryProtocol, archivedWarikanGroupRepository: ArchivedWarikanGroupRepositoryProtocol) {
+        self.warikanGroupRepository = warikanGroupRepository
+        self.archivedWarikanGroupRepository = archivedWarikanGroupRepository
+    }
+    
+    /// 指定したIDの割り勘グループを、清算済グループとしてアーカイブする。
+    ///
+    /// - parameter id: アーカイブする割り勘グループ。
+    /// - parameter seisanList: その割り勘グループで計算された清算リスト。
+    /// - parameter unluckyMember: 選ばれたアンラッキーメンバー。アンラッキーメンバーがいない場合は`nil`を渡す。
+    func archive(id: EntityID<WarikanGroup>, seisanList: [Seisan], unluckyMember: EntityID<Member>?) async throws {
+        try await warikanGroupRepository.transaction {
+            // 割り勘グループのリポジトリから削除
+            guard let target = try await warikanGroupRepository.find(id: id) else {
+                throw ValidationError.notFoundID(id)
+            }
+            try await warikanGroupRepository.remove(id: target.id)
+            
+            // 清算済グループのリポジトリに保存
+            try await archivedWarikanGroupRepository.transaction {
+                let archivedWarikanGroupID = try await archivedWarikanGroupRepository.nextID()
+                let archivedWarikanGroup = ArchivedWarikanGroup(
+                    id: archivedWarikanGroupID,
+                    name: target.name,
+                    members: target.members,
+                    tatekaeList: target.tatekaeList,
+                    unluckyMember: unluckyMember,
+                    seisanList: seisanList
+                )
+                try await archivedWarikanGroupRepository.save(archivedWarikanGroup)
+            }
+        }
+    }
+}


### PR DESCRIPTION
close #9

## 追加したユースケース
### WarikanGroupArchiveController
- 指定したIDの割り勘グループを、清算済グループとしてアーカイブする。
`func archive(id: EntityID<WarikanGroup>, seisanList: [Seisan], unluckyMember: EntityID<Member>?) async throws -> EntityID<ArchivedWarikanGroup>`
### ArchivedWarikanGroupUseCase
- 登録されている割り勘グループの配列の全体を返す。
`func getAll() async throws -> [ArchivedWarikanGroup]`
- 指定したIDの割り勘グループを削除する。
`func remove(ids: [EntityID<ArchivedWarikanGroup>]) async throws`