### PR TITLE
Change&Test: SeisanCalculatorの単体テスト作成・ロジック改良

### DIFF
--- a/Roulette.xcodeproj/project.pbxproj
+++ b/Roulette.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		A60091312B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60091302B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift */; };
 		A60091332B22A05D005C6535 /* WarikanGroupArchiveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60091322B22A05D005C6535 /* WarikanGroupArchiveController.swift */; };
 		A60091352B22B857005C6535 /* ArchivedWarikanGroupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60091342B22B857005C6535 /* ArchivedWarikanGroupUseCase.swift */; };
+		A627DBBD2B25F37800F1C451 /* SeisanCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A627DBBC2B25F37800F1C451 /* SeisanCalculatorTests.swift */; };
 		A67FE31A2B1337FA00E10FFB /* SeisanCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */; };
 		A67FE31D2B1338A900E10FFB /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE31C2B1338A900E10FFB /* Extensions.swift */; };
 		A67FE3242B14657400E10FFB /* WarikanGroupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */; };
@@ -61,6 +62,16 @@
 		A67FE35F2B21D1A600E10FFB /* MemberRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE35E2B21D1A600E10FFB /* MemberRepository.swift */; };
 		A67FE3612B21D4D100E10FFB /* TatekaeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FE3602B21D4D000E10FFB /* TatekaeRepository.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A627DBB72B25F36200F1C451 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4C228AC52AFA861B00FE4F35 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C228ACC2AFA861B00FE4F35;
+			remoteInfo = Roulette;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		4C1C38E52B1E0B7E00839663 /* AddTatekaeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTatekaeView.swift; sourceTree = "<group>"; };
@@ -99,6 +110,8 @@
 		A60091302B229D67005C6535 /* ArchivedWarikanGroupRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroupRepositoryProtocol.swift; sourceTree = "<group>"; };
 		A60091322B22A05D005C6535 /* WarikanGroupArchiveController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarikanGroupArchiveController.swift; sourceTree = "<group>"; };
 		A60091342B22B857005C6535 /* ArchivedWarikanGroupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedWarikanGroupUseCase.swift; sourceTree = "<group>"; };
+		A627DBB32B25F36200F1C451 /* RouletteTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RouletteTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A627DBBC2B25F37800F1C451 /* SeisanCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeisanCalculatorTests.swift; sourceTree = "<group>"; };
 		A67FE3192B1337FA00E10FFB /* SeisanCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeisanCalculator.swift; sourceTree = "<group>"; };
 		A67FE31C2B1338A900E10FFB /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		A67FE3232B14657400E10FFB /* WarikanGroupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarikanGroupUseCase.swift; sourceTree = "<group>"; };
@@ -127,6 +140,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A627DBB02B25F36200F1C451 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -134,6 +154,7 @@
 			isa = PBXGroup;
 			children = (
 				4C228ACF2AFA861B00FE4F35 /* Roulette */,
+				A627DBB42B25F36200F1C451 /* RouletteTests */,
 				4C228ACE2AFA861B00FE4F35 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -142,6 +163,7 @@
 			isa = PBXGroup;
 			children = (
 				4C228ACD2AFA861B00FE4F35 /* Roulette.app */,
+				A627DBB32B25F36200F1C451 /* RouletteTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -318,6 +340,14 @@
 			path = ArchivedWarikanGroup;
 			sourceTree = "<group>";
 		};
+		A627DBB42B25F36200F1C451 /* RouletteTests */ = {
+			isa = PBXGroup;
+			children = (
+				A627DBBC2B25F37800F1C451 /* SeisanCalculatorTests.swift */,
+			);
+			path = RouletteTests;
+			sourceTree = "<group>";
+		};
 		A67FE31B2B13387C00E10FFB /* Util */ = {
 			isa = PBXGroup;
 			children = (
@@ -348,6 +378,24 @@
 			productReference = 4C228ACD2AFA861B00FE4F35 /* Roulette.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A627DBB22B25F36200F1C451 /* RouletteTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A627DBBB2B25F36200F1C451 /* Build configuration list for PBXNativeTarget "RouletteTests" */;
+			buildPhases = (
+				A627DBAF2B25F36200F1C451 /* Sources */,
+				A627DBB02B25F36200F1C451 /* Frameworks */,
+				A627DBB12B25F36200F1C451 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A627DBB82B25F36200F1C451 /* PBXTargetDependency */,
+			);
+			name = RouletteTests;
+			productName = RouletteTests;
+			productReference = A627DBB32B25F36200F1C451 /* RouletteTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -360,6 +408,10 @@
 				TargetAttributes = {
 					4C228ACC2AFA861B00FE4F35 = {
 						CreatedOnToolsVersion = 15.0.1;
+					};
+					A627DBB22B25F36200F1C451 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = 4C228ACC2AFA861B00FE4F35;
 					};
 				};
 			};
@@ -379,6 +431,7 @@
 			projectRoot = "";
 			targets = (
 				4C228ACC2AFA861B00FE4F35 /* Roulette */,
+				A627DBB22B25F36200F1C451 /* RouletteTests */,
 			);
 		};
 /* End PBXProject section */
@@ -390,6 +443,13 @@
 			files = (
 				4C228AD82AFA861D00FE4F35 /* Preview Assets.xcassets in Resources */,
 				4C228AD52AFA861D00FE4F35 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A627DBB12B25F36200F1C451 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -454,7 +514,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A627DBAF2B25F36200F1C451 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A627DBBD2B25F37800F1C451 /* SeisanCalculatorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A627DBB82B25F36200F1C451 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4C228ACC2AFA861B00FE4F35 /* Roulette */;
+			targetProxy = A627DBB72B25F36200F1C451 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		4C228AD92AFA861D00FE4F35 /* Debug */ = {
@@ -634,6 +710,42 @@
 			};
 			name = Release;
 		};
+		A627DBB92B25F36200F1C451 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q7RTLG93ZX;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kakimoto.RouletteTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Roulette.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Roulette";
+			};
+			name = Debug;
+		};
+		A627DBBA2B25F36200F1C451 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q7RTLG93ZX;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kakimoto.RouletteTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Roulette.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Roulette";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -651,6 +763,15 @@
 			buildConfigurations = (
 				4C228ADC2AFA861D00FE4F35 /* Debug */,
 				4C228ADD2AFA861D00FE4F35 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A627DBBB2B25F36200F1C451 /* Build configuration list for PBXNativeTarget "RouletteTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A627DBB92B25F36200F1C451 /* Debug */,
+				A627DBBA2B25F36200F1C451 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Roulette/Model/UseCase/SeisanCalculator/DebtState.swift
+++ b/Roulette/Model/UseCase/SeisanCalculator/DebtState.swift
@@ -18,7 +18,7 @@ struct DebtState {
     }
     
     /// メンバーの借金額を格納する辞書。
-    private(set) var debtMap = [DebtMapKey: Int]()
+    private(set) var debtMap: [DebtMapKey: Int]
     
     private init(debtMap: [DebtMapKey: Int]) {
         self.debtMap = debtMap

--- a/Roulette/Model/UseCase/SeisanCalculator/DebtState.swift
+++ b/Roulette/Model/UseCase/SeisanCalculator/DebtState.swift
@@ -82,4 +82,16 @@ struct DebtState {
             }
         }
     }
+    
+    /// `debtMap` に登録されているメンバーの一覧を返す。
+    func getMembers() -> [EntityID<Member>] {
+        return debtMap.compactMap { (key: DebtMapKey, value: Int) in
+            switch key {
+            case .someone(let id):
+                return id
+            case .imaginary:
+                return nil
+            }
+        }
+    }
 }

--- a/Roulette/Model/UseCase/SeisanCalculator/DebtState.swift
+++ b/Roulette/Model/UseCase/SeisanCalculator/DebtState.swift
@@ -28,28 +28,20 @@ struct DebtState {
         self.debtMap = debtMap
     }
     
-    /// メンバーに対して借金を課す。
-    mutating func impose(money: Int, on member: EntityID<Member>) {
-        let key = DebtMapKey.someone(id: member)
-        if let nowDebt = debtMap[key] {
-            debtMap[key] = nowDebt + money
-        } else {
-            debtMap[key] = money
-        }
+    /// メンバーとDouble型の借金額の辞書型を受け取って `DebtMap` を作成する。
+    ///
+    /// 借金額は四捨五入され、整数に変換される。
+    static func create(from originalDebtMap: [EntityID<Member>: Double]) -> Self {
+        let debtMap = Dictionary(uniqueKeysWithValues: originalDebtMap.map({ (member: EntityID<Member>, debt: Double) in
+            (DebtMapKey.someone(id: member), Int(debt.rounded()))
+        }))
+        return .init(debtMap: debtMap)
     }
     
     /// 送金する。送金元の借金額を減らし、送金先の借金額を増やす。
     mutating func payMoney(_ money: Int, from fromKey: DebtMapKey, to toKey: DebtMapKey) {
-        guard let fromDebt = debtMap[fromKey] else {
-            print("[WARNING] 存在しない送金元ID:", fromKey)
-            return
-        }
-        guard let toDebt = debtMap[toKey] else {
-            print("[WARNING] 存在しない送金先ID:", toKey)
-            return
-        }
-        debtMap[fromKey] = fromDebt - money
-        debtMap[toKey] = toDebt + money
+        debtMap[fromKey] = (debtMap[fromKey] ?? 0) - money
+        debtMap[toKey] = (debtMap[toKey] ?? 0) + money
     }
     
     /// 2つの`DebtState`が保持する借金の差額を取る。

--- a/Roulette/Model/UseCase/SeisanCalculator/DebtState.swift
+++ b/Roulette/Model/UseCase/SeisanCalculator/DebtState.swift
@@ -18,11 +18,7 @@ struct DebtState {
     }
     
     /// メンバーの借金額を格納する辞書。
-    private(set) var debtMap: [DebtMapKey: Int]
-    
-    init() {
-        self.debtMap = [.imaginary: 0]
-    }
+    private(set) var debtMap = [DebtMapKey: Int]()
     
     private init(debtMap: [DebtMapKey: Int]) {
         self.debtMap = debtMap

--- a/Roulette/Model/UseCase/SeisanCalculator/SeisanCalculator.swift
+++ b/Roulette/Model/UseCase/SeisanCalculator/SeisanCalculator.swift
@@ -74,12 +74,12 @@ struct SeisanCalculator {
     
     /// 各メンバーの借金額を計算する。
     private func debts(tatekaeList: [Tatekae]) -> DebtState {
-        var debts: DebtState = DebtState()
+        var debtMap = [EntityID<Member>: Double]()
         tatekaeList.forEach { tatekae in
-            debts.impose(money: -tatekae.money, on: tatekae.payer)
-            let splitAmount = tatekae.money / tatekae.recipients.count
-            tatekae.recipients.forEach { debts.impose(money: splitAmount, on: $0) }
+            let splitAmount = Double(tatekae.money) / Double(tatekae.recipients.count)
+            debtMap[tatekae.payer] = (debtMap[tatekae.payer] ?? 0.0) - Double(tatekae.money)
+            tatekae.recipients.forEach { debtMap[$0] = (debtMap[$0] ?? 0.0) + splitAmount }
         }
-        return debts
+        return DebtState.create(from: debtMap)
     }
 }

--- a/Roulette/Model/UseCase/SeisanCalculator/SeisanCalculator.swift
+++ b/Roulette/Model/UseCase/SeisanCalculator/SeisanCalculator.swift
@@ -14,6 +14,7 @@ struct SeisanCalculator {
     struct SeisanContext {
         fileprivate let debts: DebtState
         fileprivate let zansais: DebtState
+        let unluckyMemberCandidates: [EntityID<Member>]
     }
     
     /// `seisan(tatekaeList:)`の応答。
@@ -32,7 +33,7 @@ struct SeisanCalculator {
         }
         
         if zansais.debtMap[.imaginary] != 0 {
-            let context = SeisanContext(debts: debts, zansais: zansais)
+            let context = SeisanContext(debts: debts, zansais: zansais, unluckyMemberCandidates: debts.getMembers())
             return SeisanResponse.needsUnluckyMember(context)
         } else {
             return SeisanResponse.success(seisan(seisanPrises: debts - zansais))

--- a/RouletteTests/SeisanCalculatorTests.swift
+++ b/RouletteTests/SeisanCalculatorTests.swift
@@ -87,8 +87,11 @@ final class SeisanCalculatorTests: XCTestCase {
         
         switch response {
         case .needsUnluckyMember(let context):
-            let unluckyMember = seig
-            let seisanList = calculator.seisan(context: context, unluckyMember: unluckyMember)
+            XCTAssertEqual(Set(context.unluckyMemberCandidates), Set([sako, seig, maki]))
+            
+            // アンラッキーメンバーを指定して計算続行
+            let seisanList = calculator.seisan(context: context, unluckyMember: seig)
+            
             let result = seisanList.descript(with: members)
             XCTAssertEqual(result, """
             霽月 -> さこ: 140円

--- a/RouletteTests/SeisanCalculatorTests.swift
+++ b/RouletteTests/SeisanCalculatorTests.swift
@@ -137,5 +137,34 @@ final class SeisanCalculatorTests: XCTestCase {
             XCTFail()
         }
     }
+    
+    func test_case04_清算が不要の場合は空配列を返す() throws {
+        let members = [
+            createMember(name: "さこ"),
+            createMember(name: "霽月"),
+            createMember(name: "まき")
+        ]
+        let sako = members[0].id
+        let seig = members[1].id
+        let maki = members[2].id
+        
+        let tatekaeList = [
+            createTatekae(name: "昼飯代", payer: sako, recipients: [sako, seig, maki], money: 1000),
+            createTatekae(name: "タクシー代", payer: seig, recipients: [sako, seig], money: 667),
+            createTatekae(name: "宿代", payer: maki, recipients: [sako, maki], money: 667)
+        ]
+        
+        // 計算実行
+        let calculator = SeisanCalculator()
+        let response = calculator.seisan(tatekaeList: tatekaeList)
+        
+        switch response {
+        case .success(let seisanList):
+            XCTAssertTrue(seisanList.isEmpty)
+            
+        default:
+            XCTFail()
+        }
+    }
 
 }

--- a/RouletteTests/SeisanCalculatorTests.swift
+++ b/RouletteTests/SeisanCalculatorTests.swift
@@ -1,0 +1,103 @@
+//
+//  SeisanCalculatorTests.swift
+//  RouletteTests
+//  
+//  Created by Seigetsu on 2023/12/10
+//  
+//
+
+import XCTest
+@testable import Roulette
+
+fileprivate extension [Seisan] {
+    func descript(with members: [Member]) -> String {
+        let names = Dictionary(uniqueKeysWithValues: members.map { ($0.id, $0.name) })
+        return self.map { seisan in
+            let a = names[seisan.debtor]!
+            let b = names[seisan.creditor]!
+            return "\(a) -> \(b): \(seisan.money)円"
+        }.joined(separator: "\n")
+    }
+}
+
+final class SeisanCalculatorTests: XCTestCase {
+
+    private func createMember(name: String) -> Member {
+        let id = EntityID<Member>(value: UUID().uuidString)
+        return Member(id: id, name: name)
+    }
+    
+    private func createTatekae(name: String, payer: EntityID<Member>, recipients: [EntityID<Member>], money: Int) -> Tatekae {
+        let id = EntityID<Tatekae>(value: UUID().uuidString)
+        return Tatekae(id: id, name: name, payer: payer, recipients: recipients, money: money)
+    }
+    
+    func test_case01_success() throws {
+        let members = [
+            createMember(name: "さこ"),
+            createMember(name: "霽月"),
+            createMember(name: "まき")
+        ]
+        let sako = members[0].id
+        let seig = members[1].id
+        let maki = members[2].id
+        
+        let tatekaeList = [
+            createTatekae(name: "昼飯代", payer: sako, recipients: [sako, seig, maki], money: 1200),
+            createTatekae(name: "タクシー代", payer: seig, recipients: [sako, seig, maki], money: 900),
+            createTatekae(name: "宿代", payer: maki, recipients: [sako, seig, maki], money: 1080)
+        ]
+        
+        // 計算実行
+        let calculator = SeisanCalculator()
+        let response = calculator.seisan(tatekaeList: tatekaeList)
+        
+        switch response {
+        case .success(let seisanList):
+            let result = seisanList.descript(with: members)
+            XCTAssertEqual(result, """
+            霽月 -> さこ: 140円
+            霽月 -> まき: 20円
+            """)
+            
+        default:
+            XCTFail()
+        }
+    }
+    
+    func test_case02_needsUnluckyMember() throws {
+        let members = [
+            createMember(name: "さこ"),
+            createMember(name: "霽月"),
+            createMember(name: "まき")
+        ]
+        let sako = members[0].id
+        let seig = members[1].id
+        let maki = members[2].id
+        
+        let tatekaeList = [
+            createTatekae(name: "昼飯代", payer: sako, recipients: [sako, seig, maki], money: 1200),
+            createTatekae(name: "タクシー代", payer: seig, recipients: [sako, seig, maki], money: 900),
+            createTatekae(name: "宿代", payer: maki, recipients: [sako, seig, maki], money: 1100)
+        ]
+        
+        // 計算実行
+        let calculator = SeisanCalculator()
+        let response = calculator.seisan(tatekaeList: tatekaeList)
+        
+        switch response {
+        case .needsUnluckyMember(let context):
+            let unluckyMember = seig
+            let seisanList = calculator.seisan(context: context, unluckyMember: unluckyMember)
+            let result = seisanList.descript(with: members)
+            XCTAssertEqual(result, """
+            霽月 -> さこ: 140円
+            霽月 -> まき: 40円
+            """)
+            
+        default:
+            XCTFail()
+        }
+    }
+
+}

--- a/RouletteTests/SeisanCalculatorTests.swift
+++ b/RouletteTests/SeisanCalculatorTests.swift
@@ -102,5 +102,40 @@ final class SeisanCalculatorTests: XCTestCase {
             XCTFail()
         }
     }
+    
+    func test_case03_アンラッキーメンバー候補() throws {
+        let members = [
+            createMember(name: "さこ"),
+            createMember(name: "霽月"),
+            createMember(name: "まき")
+        ]
+        let sako = members[0].id
+        let seig = members[1].id
+        let maki = members[2].id
+        
+        let tatekaeList = [
+            createTatekae(name: "昼飯代", payer: seig, recipients: [sako, seig], money: 1234)
+        ]
+        
+        // 計算実行
+        let calculator = SeisanCalculator()
+        let response = calculator.seisan(tatekaeList: tatekaeList)
+        
+        switch response {
+        case .needsUnluckyMember(let context):
+            XCTAssertEqual(Set(context.unluckyMemberCandidates), Set([sako, seig]))
+            
+            // アンラッキーメンバーを指定して計算続行
+            let seisanList = calculator.seisan(context: context, unluckyMember: sako)
+            
+            let result = seisanList.descript(with: members)
+            XCTAssertEqual(result, """
+            さこ -> 霽月: 620円
+            """)
+            
+        default:
+            XCTFail()
+        }
+    }
 
 }

--- a/RouletteTests/SeisanCalculatorTests.swift
+++ b/RouletteTests/SeisanCalculatorTests.swift
@@ -111,7 +111,6 @@ final class SeisanCalculatorTests: XCTestCase {
         ]
         let sako = members[0].id
         let seig = members[1].id
-        let maki = members[2].id
         
         let tatekaeList = [
             createTatekae(name: "昼飯代", payer: seig, recipients: [sako, seig], money: 1234)


### PR DESCRIPTION
close #16

Scrapbox に載せている「立て替え計算.numbers」をご確認ください。
- 単体テストの内容 については 「SeisanCalculatorTests」のシートを参照してください。
- ロジックの変更内容 については 「新旧比較」のシートを参照してください。借金額の計算方法に変更を加えています。