### PR TITLE
Change: MainViewModelを修正

### DIFF
--- a/Roulette/ViewModels/MainViewModel.swift
+++ b/Roulette/ViewModels/MainViewModel.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+
+/// - Important: 何かを追加するという処理には、更新が付随することに注意。
 @MainActor
 final class MainViewModel: ObservableObject {
     @Published var allGroups: [WarikanGroup] = []
@@ -33,7 +35,7 @@ final class MainViewModel: ObservableObject {
         self.tatekaeUsecase = TatekaeUsecase(tatekaeRepository: tatekaeRepository)
     }
 
-    func fecthAllGroups() async {
+    func getAllWarikanGroups() async {
         do {
             allGroups = try await warikanGroupUseCase.getAll()
         } catch {
@@ -44,13 +46,13 @@ final class MainViewModel: ObservableObject {
     func createWarikanGroup(name: String, memberNames: [String]) async {
         do {
             try await warikanGroupUseCase.create(name: name, memberNames: memberNames)
-            await fecthAllGroups()
+            await getAllWarikanGroups()
         } catch {
             print(#function, error)
         }
     }
     
-    func getTatakaeList(id: EntityID<WarikanGroup>) async {
+    func getSelectedGroupTatakaeList(id: EntityID<WarikanGroup>) async {
         do {
             selectedGroupTatekaes = try await warikanGroupUseCase.getTatekaeList(id: id)
         } catch {
@@ -58,7 +60,7 @@ final class MainViewModel: ObservableObject {
         }
     }
 
-    func getMembers(ids: [EntityID<Member>]) async {
+    func getSelectedGroupMembers(ids: [EntityID<Member>]) async {
         do {
             selectedGroupMembers = try await memberUsecase.get(ids: ids)
         } catch {          
@@ -71,7 +73,8 @@ final class MainViewModel: ObservableObject {
             let member = try await memberUsecase.get(id: id)!
             return member
         } catch {
-            print(#function, error); fatalError();
+            print(#function, error)
+            fatalError()
         }
     }
 
@@ -90,6 +93,7 @@ final class MainViewModel: ObservableObject {
                 recipants: recipantIDs,
                 money: money
             )
+            await getSelectedGroupTatakaeList(id: warikanGroupID)
         } catch {
             print(#function, error)
         }

--- a/Roulette/ViewModels/MainViewModel.swift
+++ b/Roulette/ViewModels/MainViewModel.swift
@@ -9,9 +9,12 @@ import Foundation
 
 @MainActor
 final class MainViewModel: ObservableObject {
-    @Published var groups: [WarikanGroup] = []
-    @Published var members: [Member] = []
-    @Published var tatekaes: [Tatekae] = []
+    @Published var allGroups: [WarikanGroup] = []
+
+    @Published var selectedGroup: WarikanGroup?
+    @Published var selectedGroupMembers: [Member]?
+    @Published var selectedGroupTatekaes: [Tatekae]?
+
     private let warikanGroupUseCase: WarikanGroupUsecase
     private let memberUsecase: MemberUsecase
     private let tatekaeUsecase: TatekaeUsecase
@@ -32,7 +35,7 @@ final class MainViewModel: ObservableObject {
 
     func fecthAllGroups() async {
         do {
-            groups = try await warikanGroupUseCase.getAll()
+            allGroups = try await warikanGroupUseCase.getAll()
         } catch {
             print(#function, error)
         }
@@ -49,7 +52,7 @@ final class MainViewModel: ObservableObject {
     
     func getTatakaeList(id: EntityID<WarikanGroup>) async {
         do {
-            tatekaes = try await warikanGroupUseCase.getTatekaeList(id: id)
+            selectedGroupTatekaes = try await warikanGroupUseCase.getTatekaeList(id: id)
         } catch {
             print(#function, error)
         }
@@ -57,7 +60,7 @@ final class MainViewModel: ObservableObject {
 
     func getMembers(ids: [EntityID<Member>]) async {
         do {
-            members = try await memberUsecase.get(ids: ids)
+            selectedGroupMembers = try await memberUsecase.get(ids: ids)
         } catch {          
             print(#function, error)
         }

--- a/Roulette/ViewModels/MainViewModel.swift
+++ b/Roulette/ViewModels/MainViewModel.swift
@@ -9,32 +9,32 @@ import Foundation
 
 @MainActor
 final class MainViewModel: ObservableObject {
-    @Published var members: [Member] = []
     @Published var groups: [WarikanGroup] = []
+    @Published var members: [Member] = []
     @Published var tatekaes: [Tatekae] = []
     private let warikanGroupUseCase: WarikanGroupUsecase
     private let memberUsecase: MemberUsecase
+    private let tatekaeUsecase: TatekaeUsecase
 
     init() {
         let warikanGroupRepository = WarikanGroupRepository(userDefaultsKey: "warikanGroup")
         let memberRepository = MemberRepository(userDefaultsKey: "member")
         let tatekaeRepository = TatekaeRepository(userDefaultsKey: "tatekae")
 
-        self.memberUsecase = MemberUsecase(memberRepository: memberRepository)
         self.warikanGroupUseCase = WarikanGroupUsecase(
             warikanGroupRepository: warikanGroupRepository,
             memberRepository: memberRepository,
             tatekaeRepository: tatekaeRepository
         )
+        self.memberUsecase = MemberUsecase(memberRepository: memberRepository)
+        self.tatekaeUsecase = TatekaeUsecase(tatekaeRepository: tatekaeRepository)
     }
 
     func fecthAllGroups() async {
-        print("fetchGroupAllが呼ばれました。")
         do {
             groups = try await warikanGroupUseCase.getAll()
-            print("groups", groups)
         } catch {
-            print(error)
+            print(#function, error)
         }
     }
     
@@ -43,7 +43,7 @@ final class MainViewModel: ObservableObject {
             try await warikanGroupUseCase.create(name: name, memberNames: memberNames)
             await fecthAllGroups()
         } catch {
-            print(#file, #line, "couldn't create")
+            print(#function, error)
         }
     }
     
@@ -51,17 +51,15 @@ final class MainViewModel: ObservableObject {
         do {
             tatekaes = try await warikanGroupUseCase.getTatekaeList(id: id)
         } catch {
-//             print("error:", error)
-//             print(#file, #line)
+            print(#function, error)
         }
     }
 
     func getMembers(ids: [EntityID<Member>]) async {
         do {
             members = try await memberUsecase.get(ids: ids)
-        } catch {
-            print("error:", error)
-            print(#file, #line)
+        } catch {          
+            print(#function, error)
         }
     }
     
@@ -70,9 +68,7 @@ final class MainViewModel: ObservableObject {
             let member = try await memberUsecase.get(id: id)!
             return member
         } catch {
-            print("error:", error)
-            print(#file, #line)
-            fatalError()
+            print(#function, error); fatalError();
         }
     }
 
@@ -92,8 +88,7 @@ final class MainViewModel: ObservableObject {
                 money: money
             )
         } catch {
-//             print("error:", error)
-//             print(#file, #line)
+            print(#function, error)
         }
     }
 }


### PR DESCRIPTION
1. MainViewModelのプロパティを変更
全ての割り勘グループ
@Published var allGroups: [WarikanGroup] = []
選択(使用)されているグループ、及びそのメンバーと立替の一覧
@Published var selectedGroup: WarikanGroup?
@Published var selectedGroupMembers: [Member]?
@Published var selectedGroupTatekaes: [Tatekae]?

2. プロパティ名変更に伴う関数名の修正
3. エラー時の出力の統一