### PR TITLE
Feature&Change: SeisanResultViewのダミーテキストをMainViewModelがもつプロパティに応じたテキストに置換"

### DIFF
--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct SeisanResultView: View {
     @EnvironmentObject private var viewRouter: ViewRouter
-    
+    @EnvironmentObject private var mainViewModel: MainViewModel
+
     var body: some View {
         List {
             Section {
@@ -54,4 +55,5 @@ struct SeisanResultView: View {
 #Preview {
     SeisanResultView()
         .environmentObject(ViewRouter())
+        .environmentObject(MainViewModel())
 }

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -48,14 +48,15 @@ struct SeisanResultView: View {
             }
             // 合計金額セクション
             Section {
-                if let tatekaes = mainViewModel.selectedGroupTatekaes {
+                switch mainViewModel.selectedGroupTatekaes {
+                case .some(let tatekaes):
                     let sum = tatekaes.reduce(0) { partialResult, tatekae in
                         partialResult + tatekae.money
                     }
                     Text("\(sum)円")
                         .padding(.top, 3)
-                } else {
-                    Text("???円")
+                case .none:
+                    Text("読み込みエラー")
                         .padding(.top, 3)
                 }
             } header: {

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -13,6 +13,7 @@ struct SeisanResultView: View {
     
     var body: some View {
         List {
+            // 立替セクション
             Section {
                 if let tatekaes = mainViewModel.selectedGroupTatekaes {
                     HStack {
@@ -32,6 +33,7 @@ struct SeisanResultView: View {
             } header: {
                 Text("立替一覧")
             }
+            // アンラッキーメンバーセクション
             Section {
                 if case .success = mainViewModel.selectedGroupSeisanResponse {
                     Text("なし")
@@ -42,6 +44,7 @@ struct SeisanResultView: View {
             } header: {
                 Text("アンラッキーメンバー")
             }
+            // 合計金額セクション
             Section {
                 if let tatekaes = mainViewModel.selectedGroupTatekaes {
                     let sum = tatekaes.reduce(0) { partialResult, tatekae in
@@ -56,6 +59,7 @@ struct SeisanResultView: View {
             } header: {
                 Text("合計金額")
             }
+            // 精算結果セクション
             Section {
                 switch mainViewModel.selectedGroupSeisanResponse {
                 // アンラッキーメンバーあり

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SeisanResultView: View {
     @EnvironmentObject private var viewRouter: ViewRouter
     @EnvironmentObject private var mainViewModel: MainViewModel
-
+    
     var body: some View {
         List {
             Section {
@@ -33,6 +33,16 @@ struct SeisanResultView: View {
                 Text("立替一覧")
             }
             Section {
+                if case .success = mainViewModel.selectedGroupSeisanResponse {
+                    Text("なし")
+                        .padding(.top, 3)
+                } else {
+                    Text("アンラッキーメンバー名をここに記載")
+                }
+            } header: {
+                Text("アンラッキーメンバー")
+            }
+            Section {
                 if let tatekaes = mainViewModel.selectedGroupTatekaes {
                     let sum = tatekaes.reduce(0) { partialResult, tatekae in
                         partialResult + tatekae.money
@@ -47,17 +57,22 @@ struct SeisanResultView: View {
                 Text("合計金額")
             }
             Section {
-                Text("Sako")
-                    .padding(.top, 3)
-            } header: {
-                Text("アンラッキーメンバー")
-            }
-            Section {
-                VStack(alignment: .leading) {
-                    Text("SeigetsuがSakoに3,300円渡す")
-                        .padding(.top, 3)
-                    Text("MakiがSakoに3,300円渡す")
-                        .padding(.top, 3)
+                switch mainViewModel.selectedGroupSeisanResponse {
+                // アンラッキーメンバーあり
+                case .needsUnluckyMember:
+                    Text("アンラッキーメンバーがいる場合の記述")
+                // アンラッキーメンバーなし & 精算なし
+                case .success(let seisanDataList) where seisanDataList.isEmpty:
+                    Text("精算なし")
+                // アンラッキーメンバーなし & 精算あり
+                case .success(let seisanDataList):
+                    ForEach(seisanDataList.indices, id: \.self) { index in
+                        let seisanData = seisanDataList[index]
+                        Text("\(seisanData.debtor.name)が\(seisanData.creditor.name)に\(seisanData.money)円渡す")
+                    }
+                // その他
+                case .none:
+                    Text("Error")
                 }
             } header: {
                 Text("精算結果")

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -32,11 +32,16 @@ struct SeisanResultView: View {
             }
             // アンラッキーメンバーセクション
             Section {
-                if case .success = mainViewModel.selectedGroupSeisanResponse {
+                switch mainViewModel.selectedGroupSeisanResponse {
+                case .needsUnluckyMember:
+                    Text("アンラッキーメンバー名をここに記載")
+                        .padding(.top, 3)
+                case .success:
                     Text("なし")
                         .padding(.top, 3)
-                } else {
-                    Text("アンラッキーメンバー名をここに記載")
+                case .none:
+                    Text("読み込みエラー")
+                        .padding(.top, 3)
                 }
             } header: {
                 Text("アンラッキーメンバー")

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -15,20 +15,17 @@ struct SeisanResultView: View {
         List {
             // 立替セクション
             Section {
-                if let tatekaes = mainViewModel.selectedGroupTatekaes {
+                switch mainViewModel.selectedGroupTatekaes {
+                case .some(let tatekaes):
                     HStack {
                         ForEach(tatekaes) { tatekae in
                             Text(tatekae.name)
                         }
                     }
                     .padding(.top, 3)
-                } else {
-                    HStack {
-                        Text("???")
-                        Text("???")
-                        Text("???")
-                    }
-                    .padding(.top, 3)
+                case .none:
+                    Text("読み込みエラー")
+                        .padding(.top, 3)
                 }
             } header: {
                 Text("立替一覧")

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -79,7 +79,7 @@ struct SeisanResultView: View {
                     }
                 // その他
                 case .none:
-                    Text("Error")
+                    Text("読み込みエラー")
                 }
             } header: {
                 Text("精算結果")

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -33,8 +33,16 @@ struct SeisanResultView: View {
                 Text("立替一覧")
             }
             Section {
-                Text("10,000円")
-                    .padding(.top, 3)
+                if let tatekaes = mainViewModel.selectedGroupTatekaes {
+                    let sum = tatekaes.reduce(0) { partialResult, tatekae in
+                        partialResult + tatekae.money
+                    }
+                    Text("\(sum)円")
+                        .padding(.top, 3)
+                } else {
+                    Text("???円")
+                        .padding(.top, 3)
+                }
             } header: {
                 Text("合計金額")
             }

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SeisanResultView: View {
     @EnvironmentObject private var viewRouter: ViewRouter
     @EnvironmentObject private var mainViewModel: MainViewModel
-    
+
     var body: some View {
         List {
             // 立替セクション

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -14,8 +14,21 @@ struct SeisanResultView: View {
     var body: some View {
         List {
             Section {
-                Text("朝食、昼食、夕食")
+                if let tatekaes = mainViewModel.selectedGroupTatekaes {
+                    HStack {
+                        ForEach(tatekaes) { tatekae in
+                            Text(tatekae.name)
+                        }
+                    }
                     .padding(.top, 3)
+                } else {
+                    HStack {
+                        Text("???")
+                        Text("???")
+                        Text("???")
+                    }
+                    .padding(.top, 3)
+                }
             } header: {
                 Text("立替一覧")
             }


### PR DESCRIPTION
- feat: SeisanResultViewにMainViewModelを付与
- change: 立替一覧のダミーテキストをMainViewModelがもつtatekaesに変更
- change: 合計金額のダミーテキストをMainViewModelがもつtatekaesの合計金額に変更
- change: 合計金額と精算結果のダミーテキストをMainViewModelがもつtatekaesの合計金額及びseisanResponseに変更
- docs: セクション名を記載
- chore: 無駄なスペースの削除
- refactor: 立替セクションの条件分岐をif文からswitch文に変更
- refactor: アンラッキーメンバーセクションの条件分岐をif文からswitch文に変更
- refactor: 合計金額セクションの条件分岐をif文からswitch文に変更
- change: selectedGroupSeisanResponseがnilだった場合のテキストを変更
