### PR TITLE
Fix: ArchivedSeisanResultview.viewDataに対して@publishedを付与

### DIFF
--- a/Roulette.xcodeproj/project.pbxproj
+++ b/Roulette.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		4C3EB2CC2B1DE63600423444 /* ViewRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3EB2CB2B1DE63600423444 /* ViewRouter.swift */; };
 		4C3EB2CE2B1DEA9F00423444 /* AddGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3EB2CD2B1DEA9F00423444 /* AddGroupView.swift */; };
 		4C3EB2D02B1DEE5100423444 /* TatekaeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3EB2CF2B1DEE5100423444 /* TatekaeListView.swift */; };
+		4C44E82C2B688FA000DC653F /* ArchivedSeisanResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C44E82B2B688FA000DC653F /* ArchivedSeisanResultViewModel.swift */; };
 		4C65282B2B220231000E8130 /* LongStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C65282A2B220231000E8130 /* LongStyle.swift */; };
 		4C6528382B220D01000E8130 /* GroupListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6528372B220D01000E8130 /* GroupListViewModel.swift */; };
 		4C65283A2B220D3C000E8130 /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6528392B220D3C000E8130 /* ContentViewModel.swift */; };
@@ -98,6 +99,7 @@
 		4C3EB2CB2B1DE63600423444 /* ViewRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewRouter.swift; sourceTree = "<group>"; };
 		4C3EB2CD2B1DEA9F00423444 /* AddGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddGroupView.swift; sourceTree = "<group>"; };
 		4C3EB2CF2B1DEE5100423444 /* TatekaeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TatekaeListView.swift; sourceTree = "<group>"; };
+		4C44E82B2B688FA000DC653F /* ArchivedSeisanResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedSeisanResultViewModel.swift; sourceTree = "<group>"; };
 		4C65282A2B220231000E8130 /* LongStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongStyle.swift; sourceTree = "<group>"; };
 		4C6528372B220D01000E8130 /* GroupListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupListViewModel.swift; sourceTree = "<group>"; };
 		4C6528392B220D3C000E8130 /* ContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				4C6528472B220DC9000E8130 /* RouletteResultViewModel.swift */,
 				4C6528492B220DD9000E8130 /* SeisanResultViewModel.swift */,
 				4C65284B2B220DEB000E8130 /* ArchiveViewModel.swift */,
+				4C44E82B2B688FA000DC653F /* ArchivedSeisanResultViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -560,6 +563,7 @@
 				4C3EB2C82B1DE4A600423444 /* GroupListView.swift in Sources */,
 				69D8F3EE2B1F4ACE00B24D4E /* SeisanResultView.swift in Sources */,
 				A67FE3572B1C98F600E10FFB /* InMemoryTatekaeRepository.swift in Sources */,
+				4C44E82C2B688FA000DC653F /* ArchivedSeisanResultViewModel.swift in Sources */,
 				A695B61D2B345A000059B78D /* ArchivedWarikanGroupData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Roulette/ViewModels/ArchiveViewModel.swift
+++ b/Roulette/ViewModels/ArchiveViewModel.swift
@@ -9,8 +9,7 @@ import Foundation
 
 @MainActor
 final class ArchiveViewModel: ObservableObject {
-    @Published private(set) var archivedWarikanGroupsDataList: [ArchivedWarikanGroupData] = []
-    
+    @Published private(set) var archivedWarikanGroupDataList: [ArchivedWarikanGroupData] = []
     private let archivedWarikanGroupUseCase: ArchivedWarikanGroupUseCase
     private let memberUsecase: MemberUsecase
     private let tatekaeUsecase: TatekaeUsecase
@@ -33,9 +32,9 @@ final class ArchiveViewModel: ObservableObject {
         self.tatekaeUsecase = tatekaeUsecase
     }
     
-    func getAllArchivedWarikanGroups() async {
+    func getArchivedWarikanGroupDataList() async {
         do {
-            archivedWarikanGroupsDataList = try await archivedWarikanGroupUseCase.getAll()
+            archivedWarikanGroupDataList = try await archivedWarikanGroupUseCase.getAll()
         } catch {
             print(#function, error)
         }

--- a/Roulette/ViewModels/ArchivedSeisanResultViewModel.swift
+++ b/Roulette/ViewModels/ArchivedSeisanResultViewModel.swift
@@ -1,0 +1,77 @@
+//
+//  ArchivedSeisanResultViewModel.swift
+//  Roulette
+//
+//  Created by Masaki Doi on 2024/01/30.
+//
+
+import Foundation
+
+@MainActor
+final class ArchivedSeisanResultViewModel: ObservableObject {
+    private let archivedWarikanGroupData: ArchivedWarikanGroupData
+    private(set) var viewData: ViewData?
+    private let archivedWarikanGroupUseCase: ArchivedWarikanGroupUseCase
+    private let memberUsecase: MemberUsecase
+    private let tatekaeUsecase: TatekaeUsecase
+
+    // Viewが必要とする割り勘グループのデータ
+    struct ViewData {
+        let tatekaeList: [String]
+        let totalAmount: String
+        let unluckeyMember: String?
+        let seisanList: [(debtor: String, creditor: String, money: String)]
+        // swiftlint:disable:previous large_tuple
+    }
+
+    init(archivedWarikanGroupData: ArchivedWarikanGroupData) {
+        self.archivedWarikanGroupData = archivedWarikanGroupData
+
+        let archivedWarikanGroupRepository = ArchivedWarikanGroupRepository(userDefaultsKey: "archivedWarikanGroup")
+        let memberRepository = MemberRepository(userDefaultsKey: "member")
+        let archivedWarikanGroupUseCase = ArchivedWarikanGroupUseCase(
+            archivedWarikanGroupRepository: archivedWarikanGroupRepository,
+            memberRepository: memberRepository
+        )
+        let memberUsecase = MemberUsecase(memberRepository: memberRepository)
+        let tatekaeRepository = TatekaeRepository(userDefaultsKey: "tatekae")
+        let tatekaeUsecase = TatekaeUsecase(tatekaeRepository: tatekaeRepository)
+
+        self.archivedWarikanGroupUseCase = archivedWarikanGroupUseCase
+        self.memberUsecase = memberUsecase
+        self.tatekaeUsecase = tatekaeUsecase
+    }
+
+    // `ViewData`の生成を行う関数
+    func getGroupData() async {
+        // tatekaeListプロパティの準備
+        let tatekaes = try! await tatekaeUsecase.get(
+            ids: archivedWarikanGroupData.tatekaeList
+        )
+        let tatekaeList = tatekaes.map { $0.name }
+        // totalAmountプロパティの準備
+        let totalAmount = tatekaes.reduce(0) { partialResult, tatekae in
+            partialResult + tatekae.money
+        }
+        // unluckeyMemberプロパティの準備
+        var unluckyMember: String?
+        if let unluckeyMemberID = archivedWarikanGroupData.unluckyMember {
+            unluckyMember = try! await memberUsecase.get(id: unluckeyMemberID)?.name
+        }
+        // seisanListプロパティの準備
+        let seisanList = archivedWarikanGroupData.seisanList.map { seisanData in
+            let debtor = seisanData.debtor
+            let creditor = seisanData.creditor
+            let money = seisanData.money.description
+            return (debtor: debtor.name, creditor: creditor.name, money: money)
+        }
+        // `ViewData`の生成
+        let viewData = ViewData(
+            tatekaeList: tatekaeList,
+            totalAmount: totalAmount.description,
+            unluckeyMember: unluckyMember,
+            seisanList: seisanList
+        )
+        self.viewData = viewData
+    }
+}

--- a/Roulette/ViewModels/ArchivedSeisanResultViewModel.swift
+++ b/Roulette/ViewModels/ArchivedSeisanResultViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 @MainActor
 final class ArchivedSeisanResultViewModel: ObservableObject {
     private let archivedWarikanGroupData: ArchivedWarikanGroupData
-    private(set) var viewData: ViewData?
+    @Published private(set) var viewData: ViewData?
     private let archivedWarikanGroupUseCase: ArchivedWarikanGroupUseCase
     private let memberUsecase: MemberUsecase
     private let tatekaeUsecase: TatekaeUsecase

--- a/Roulette/Views/ArchiveView.swift
+++ b/Roulette/Views/ArchiveView.swift
@@ -8,23 +8,16 @@
 import SwiftUI
 
 struct ArchiveView: View {
-    let groups: [String]
-    init(groups: [String] = ["Gang of Five", "ひなっこクラブ", "アプリ道場サロン"]) {
-        self.groups = groups
-    }
-    
     @StateObject private var archiveViewModel = ArchiveViewModel()
     
     var body: some View {
         NavigationStack {
-            Group {
-                if groups != [] {
-                    List {
-                        ForEach(groups, id: \.self) { group in
-                            NavigationLink(group) {
-                                ArchivedSeisanResultView()
-                                    .navigationTitle("清算結果")
-                            }
+            VStack {
+                if archiveViewModel.archivedWarikanGroupDataList.isEmpty {
+                    List(archiveViewModel.archivedWarikanGroupDataList) { data in
+                        NavigationLink(data.name) {
+                            #warning("ArchivedSeisanResultViewの完成後NavigationLinkに書き換えを行う。")
+                            Text(data.name)
                         }
                     }
                 } else {
@@ -34,6 +27,9 @@ struct ArchiveView: View {
                 }
             }
             .navigationTitle("清算済割り勘グループ")
+            .task {
+                await archiveViewModel.getArchivedWarikanGroupDataList()
+            }
         }
     }
 }

--- a/Roulette/Views/ArchiveView.swift
+++ b/Roulette/Views/ArchiveView.swift
@@ -13,7 +13,7 @@ struct ArchiveView: View {
     var body: some View {
         NavigationStack {
             VStack {
-                if archiveViewModel.archivedWarikanGroupDataList.isEmpty {
+                if !archiveViewModel.archivedWarikanGroupDataList.isEmpty {
                     List(archiveViewModel.archivedWarikanGroupDataList) { data in
                         NavigationLink(data.name) {
                             ArchivedSeisanResultView(archivedWarikanGroupData: data)

--- a/Roulette/Views/ArchiveView.swift
+++ b/Roulette/Views/ArchiveView.swift
@@ -9,15 +9,14 @@ import SwiftUI
 
 struct ArchiveView: View {
     @StateObject private var archiveViewModel = ArchiveViewModel()
-    
+
     var body: some View {
         NavigationStack {
             VStack {
                 if archiveViewModel.archivedWarikanGroupDataList.isEmpty {
                     List(archiveViewModel.archivedWarikanGroupDataList) { data in
                         NavigationLink(data.name) {
-                            #warning("ArchivedSeisanResultViewの完成後NavigationLinkに書き換えを行う。")
-                            Text(data.name)
+                            ArchivedSeisanResultView(archivedWarikanGroupData: data)
                         }
                     }
                 } else {

--- a/Roulette/Views/ArchivedSeisanResultView.swift
+++ b/Roulette/Views/ArchivedSeisanResultView.swift
@@ -8,42 +8,54 @@
 import SwiftUI
 
 struct ArchivedSeisanResultView: View {
+    @StateObject private var viewModel: ArchivedSeisanResultViewModel
+
     var body: some View {
-        List {
-            Section {
-                Text("朝食、昼食、夕食")
-                    .padding(.top, 3)
-            } header: {
-                Text("立替一覧")
-            }
-            Section {
-                Text("10,000円")
-                    .padding(.top, 3)
-            } header: {
-                Text("合計金額")
-            }
-            Section {
-                Text("Sako")
-                    .padding(.top, 3)
-            } header: {
-                Text("アンラッキーメンバー")
-            }
-            Section {
-                VStack(alignment: .leading) {
-                    Text("SeigetsuがSakoに3,300円渡す")
+        VStack {
+            if let viewData = viewModel.viewData {
+                List {
+                    Section {
+                        ForEach(viewData.tatekaeList.indices, id: \.self) { i in
+                            Text(viewData.tatekaeList[i])
+                                .padding(.top, 3)
+                        }
+                    } header: {
+                        Text("立替一覧")
+                    }
+                    Section {
+                        Text("\(viewData.totalAmount)円")
+                            .padding(.top, 3)
+                    } header: {
+                        Text("合計金額")
+                    }
+                    Section {
+                        Text(
+                            viewData.unluckeyMember != nil ?
+                            viewData.unluckeyMember! : "なし"
+                        )
                         .padding(.top, 3)
-                    Text("MakiがSakoに3,300円渡す")
-                        .padding(.top, 3)
+                    } header: {
+                        Text("アンラッキーメンバー")
+                    }
+                    Section {
+                        VStack(alignment: .leading) {
+                            ForEach(viewData.seisanList.indices, id: \.self) { i in
+                                let seisanData = viewData.seisanList[i]
+                                Text("\(seisanData.debtor)が\(seisanData.creditor)に\(seisanData.money)円渡す。")
+                            }
+                        }
+                    } header: {
+                        Text("精算結果")
+                    }
                 }
-            } header: {
-                Text("精算結果")
+                .listStyle(.plain)
+            } else {
+                Text("データの読み込みに失敗しました。")
             }
         }
-        .listStyle(.plain)
         .font(.title3)
+        .task {
+            await viewModel.getGroupData()
+        }
     }
-}
-
-#Preview {
-    ArchivedSeisanResultView()
 }

--- a/Roulette/Views/ArchivedSeisanResultView.swift
+++ b/Roulette/Views/ArchivedSeisanResultView.swift
@@ -10,6 +10,14 @@ import SwiftUI
 struct ArchivedSeisanResultView: View {
     @StateObject private var viewModel: ArchivedSeisanResultViewModel
 
+    init(archivedWarikanGroupData: ArchivedWarikanGroupData) {
+        self._viewModel = StateObject(
+            wrappedValue: ArchivedSeisanResultViewModel(
+                archivedWarikanGroupData: archivedWarikanGroupData
+            )
+        )
+    }
+
     var body: some View {
         VStack {
             if let viewData = viewModel.viewData {


### PR DESCRIPTION
- refactor: 変数名、関数名の修正及び不要なスペースの削除
- change: ArchiveViewにViewModel内のデータをリスト表示させるよう変更
- add: ArchivedSeisanResultViewModelの作成
- change: ArchivedSeisanResultViewのダミーデータをViewModelのデータに置き換え
- change: ArchivedSeisanResultViewにて@StateObject用のイニシャライザを作成
- change: ダミーのTextインスタンスをArchivedSeisanResultViewへのNavigationLinkに変更
- fix: 条件式の修正
- fix: ArchivedSeisanResultView.viewDataに対して@Publishedを付与
