### PR TITLE
Fix: グループ作成から精算完了までの作業を行った際に、前回のグループの状態を保持し続けてしまうリスクに対応

### DIFF
--- a/Roulette/ViewModels/MainViewModel.swift
+++ b/Roulette/ViewModels/MainViewModel.swift
@@ -166,4 +166,12 @@ final class MainViewModel: ObservableObject {
             print(#function, error)
         }
     }
+
+    func didTapBackToTopButtonAction() {
+       selectedGroup = nil
+       selectedGroupMembers = nil
+       selectedGroupTatekaes = nil
+       selectedGroupSeisanResponse = nil
+       unluckyMemberName = nil
+    }
 }

--- a/Roulette/Views/SeisanResultView.swift
+++ b/Roulette/Views/SeisanResultView.swift
@@ -83,6 +83,7 @@ struct SeisanResultView: View {
             .padding(.top)
             .overlay(alignment: .bottom) {
                 Button("トップに戻る") {
+                    mainViewModel.didTapBackToTopButtonAction()
                     viewRouter.path.removeLast(viewRouter.path.count)
                 }
             }


### PR DESCRIPTION
「グループ作成、立替追加、ルーレット、精算結果確認」の直後、「グループ作成、立替追加、（ルーレットなし）、精算結果確認」といったケースでは、MainViewModel内のunluckyMemberが更新されない。この問題に対処した。
