### PR TITLE
Fix: 追加したメンバー名がTextFieldに残り続けるバグを修正

### DIFF
--- a/Roulette/ViewModels/AddGroupViewModel/AddGroupViewModel.swift
+++ b/Roulette/ViewModels/AddGroupViewModel/AddGroupViewModel.swift
@@ -46,7 +46,9 @@ final class AddGroupViewModel: ObservableObject {
             return
         }
         memberList.append(additionalMember)
-        clearAdditionalMember()
+        Task { @MainActor in // Taskにしてる理由は Issue #222 参照
+            additionalMember.removeAll()
+        }
     }
 
     func didTapCreateGroupButton(onCompleted completedAction: @escaping () -> Void) {
@@ -59,16 +61,6 @@ final class AddGroupViewModel: ObservableObject {
             dismissFunction()
         } else {
             isShowDismissConfirmationDialog = true
-        }
-    }
-    
-    /// `additionalMember`の入力のクリア処理
-    ///
-    /// 冗長な実装に見えるが、確実にクリアするために必要。(cf. Issue #222)
-    private func clearAdditionalMember() {
-        additionalMember.append(" ")
-        Task { @MainActor in
-            additionalMember.removeAll()
         }
     }
 

--- a/Roulette/ViewModels/AddGroupViewModel/AddGroupViewModel.swift
+++ b/Roulette/ViewModels/AddGroupViewModel/AddGroupViewModel.swift
@@ -46,7 +46,7 @@ final class AddGroupViewModel: ObservableObject {
             return
         }
         memberList.append(additionalMember)
-        additionalMember.removeAll()
+        clearAdditionalMember()
     }
 
     func didTapCreateGroupButton(onCompleted completedAction: @escaping () -> Void) {
@@ -59,6 +59,16 @@ final class AddGroupViewModel: ObservableObject {
             dismissFunction()
         } else {
             isShowDismissConfirmationDialog = true
+        }
+    }
+    
+    /// `additionalMember`の入力のクリア処理
+    ///
+    /// 冗長な実装に見えるが、確実にクリアするために必要。(cf. Issue #222)
+    private func clearAdditionalMember() {
+        additionalMember.append(" ")
+        Task { @MainActor in
+            additionalMember.removeAll()
         }
     }
 


### PR DESCRIPTION
#222 で挙げた [応急的な解決法](https://github.com/ADS-Gang-of-Five/warikan-roulette/issues/222#issuecomment-2028043519) を実施したところ、実機のiPadではきちんと消えるようになりましたが、今まで正常だったシミュレータでこのバグが発生するようになりました。

このPRをレビューするにあたって、他の実機環境での改善の有無を確認して教えてもらえるとありがたいです。