### PR TITLE
change: ルーレットのサイズ調整と、NavigationBarのバックボタンを廃止。

### DIFF
--- a/Roulette/Views/RouletteView.swift
+++ b/Roulette/Views/RouletteView.swift
@@ -11,7 +11,8 @@ import Charts
 struct RouletteView: View {
     @StateObject private var viewModel: RouletteViewModel
     @Environment(\.dismiss) private var dismiss
-
+    @EnvironmentObject private var viewRouter: ViewRouter
+    
     init(warikanGroupID: EntityID<WarikanGroup>) {
         _viewModel = StateObject(
             wrappedValue: RouletteViewModel(warikanGroupID: warikanGroupID)
@@ -19,52 +20,74 @@ struct RouletteView: View {
     }
 
     var body: some View {
+        GeometryReader { geometry in
             VStack {
                 if let members = viewModel.members {
-                    Image(systemName: "triangleshape.fill")
-                        .rotationEffect(Angle(degrees: 180.0))
-                        .foregroundStyle(.red)
-                        .scaleEffect(1.3)
-                    Chart {
-                        ForEach(members) { member in
-                            SectorMark(
-                                angle: .value("", 360.0),
-                                innerRadius: MarkDimension.ratio(0.5),
-                                angularInset: 1
-                            )
-                            .cornerRadius(1)
-                            .foregroundStyle(by: .value("", member.name))
-                            .annotation(position: .overlay) {
-                                Text(member.name)
-                                    .font(.headline)
-                                    .foregroundStyle(.white)
-                                    .rotationEffect(-viewModel.angle)
+                VStack {
+                        Image(systemName: "triangleshape.fill")
+                            .rotationEffect(Angle(degrees: 180.0))
+                            .foregroundStyle(.red)
+                            .scaleEffect(1.3)
+                        Chart {
+                            ForEach(members) { member in
+                                SectorMark(
+                                    angle: .value("", 360.0),
+                                    innerRadius: MarkDimension.ratio(0.5),
+                                    angularInset: 1
+                                )
+                                .cornerRadius(1)
+                                .foregroundStyle(by: .value("", member.name))
+                                .annotation(position: .overlay) {
+                                    Text(member.name)
+                                        .font(.headline)
+                                        .foregroundStyle(.white)
+                                        .rotationEffect(-viewModel.angle)
+                                }
                             }
                         }
+                        .chartLegend(.hidden)
+                        .navigationBarBackButtonHidden(viewModel.isRouletteBottanTap)
+                        .rotationEffect(viewModel.angle)
+                        .frame(
+                            width: geometry.size.width * 0.8,
+                            height: geometry.size.height * 0.5
+                        )
+                        .padding(.top, 3)
                     }
-                    .chartLegend(.hidden)
-                    .navigationBarBackButtonHidden(viewModel.isRouletteBottanTap)
-                    .rotationEffect(viewModel.angle)
-                    .frame(width: 300, height: 300)
-                    .padding(.top, 3)
-                    if !viewModel.isRouletteBottanTap {
+                    .frame(height: geometry.size.height * 0.6)
+                    VStack {
+                        Spacer()
+                        if !viewModel.isRouletteBottanTap {
+                            Button {
+                                viewModel.didStartButtonTappedAction()
+                            } label: {
+                                Text("Start")
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(viewModel.isRouletteBottanTap ? .gray : .blue)
+                            .padding(.top)
+                        } else {
+                            if let id = viewModel.archivedWarikanGroupID {
+                                NavigationLink("Next", value: ViewRouter.Path.rouletteResultView(id))
+                                    .buttonStyle(.borderedProminent)
+                                    .padding(.top)
+                            }
+                        }
+                        Spacer()
                         Button {
-                            viewModel.didStartButtonTappedAction()
+                            viewRouter.path.removeLast()
                         } label: {
-                            Text("Start")
+                            Text("戻る")
                         }
                         .buttonStyle(.borderedProminent)
-                        .tint(viewModel.isRouletteBottanTap ? .gray : .blue)
                         .padding(.top)
-                    } else {
-                        if let id = viewModel.archivedWarikanGroupID {
-                            NavigationLink("Next", value: ViewRouter.Path.rouletteResultView(id))
-                                .buttonStyle(.borderedProminent)
-                                .padding(.top)
-                        }
+                        .opacity(viewModel.isRouletteBottanTap ? 0.0 : 1.0)
+                        Spacer()
                     }
+                    .frame(height: geometry.size.height * 0.2)
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .task {
                 await viewModel.onAppearAction()
             }
@@ -73,5 +96,6 @@ struct RouletteView: View {
                     dismiss()
                 }
             }
+        }
     }
 }

--- a/Roulette/Views/RouletteView.swift
+++ b/Roulette/Views/RouletteView.swift
@@ -46,7 +46,7 @@ struct RouletteView: View {
                             }
                         }
                         .chartLegend(.hidden)
-                        .navigationBarBackButtonHidden(viewModel.isRouletteBottanTap)
+                        .navigationBarBackButtonHidden(true)
                         .rotationEffect(viewModel.angle)
                         .frame(
                             width: geometry.size.width * 0.8,


### PR DESCRIPTION
#220 
#208 
・GeometryReaderを使って、ルーレットのサイズを自動調整
・navigationBarBackButtonHiddenを常にtrueの状態にして、戻れないよう変更